### PR TITLE
DPMS-15382 Changing JPG MIME type to JPEG

### DIFF
--- a/imageeditlibrary/src/main/java/com/xinlan/imageeditlibrary/editimage/utils/FileUtil.java
+++ b/imageeditlibrary/src/main/java/com/xinlan/imageeditlibrary/editimage/utils/FileUtil.java
@@ -4,6 +4,7 @@ import android.content.ContentValues;
 import android.content.Context;
 import android.provider.MediaStore;
 import android.text.TextUtils;
+import android.webkit.MimeTypeMap;
 
 import java.io.File;
 
@@ -17,17 +18,6 @@ public class FileUtil {
 
         File file = new File(path);
         return file.exists();
-    }
-
-    // 获取文件扩展名
-    public static String getExtensionName(String filename) {
-        if ((filename != null) && (filename.length() > 0)) {
-            int dot = filename.lastIndexOf('.');
-            if ((dot > -1) && (dot < (filename.length() - 1))) {
-                return filename.substring(dot + 1);
-            }
-        }
-        return "";
     }
 
     /**
@@ -47,7 +37,7 @@ public class FileUtil {
         }
 
         ContentValues values = new ContentValues(2);
-        String extensionName = getExtensionName(dstPath);
+        String extensionName = MimeTypeMap.getFileExtensionFromUrl(dstPath);
         values.put(MediaStore.Images.Media.MIME_TYPE, "image/" + (TextUtils.isEmpty(extensionName) ? "jpeg" : extensionName));
         values.put(MediaStore.Images.Media.DATA, dstPath);
         context.getContentResolver().insert(MediaStore.Images.Media.EXTERNAL_CONTENT_URI, values);

--- a/imageeditlibrary/src/main/java/com/xinlan/imageeditlibrary/editimage/utils/FileUtil.java
+++ b/imageeditlibrary/src/main/java/com/xinlan/imageeditlibrary/editimage/utils/FileUtil.java
@@ -1,11 +1,10 @@
 package com.xinlan.imageeditlibrary.editimage.utils;
 
+import static android.webkit.MimeTypeMap.getFileExtensionFromUrl;
 import android.content.ContentValues;
 import android.content.Context;
 import android.provider.MediaStore;
 import android.text.TextUtils;
-import android.webkit.MimeTypeMap;
-
 import java.io.File;
 
 /**
@@ -37,8 +36,9 @@ public class FileUtil {
         }
 
         ContentValues values = new ContentValues(2);
-        String extensionName = MimeTypeMap.getFileExtensionFromUrl(dstPath);
-        values.put(MediaStore.Images.Media.MIME_TYPE, "image/" + (TextUtils.isEmpty(extensionName) ? "jpeg" : extensionName));
+        String extensionName = getFileExtensionFromUrl(dstPath);
+        values.put(MediaStore.Images.Media.MIME_TYPE, "image/" + (TextUtils.isEmpty(extensionName)
+                || extensionName.equals("jpg") ? "jpeg" : extensionName));
         values.put(MediaStore.Images.Media.DATA, dstPath);
         context.getContentResolver().insert(MediaStore.Images.Media.EXTERNAL_CONTENT_URI, values);
     }


### PR DESCRIPTION
## Description
This PR aims to change the `image/jpg` MIME type to `image/jpeg`, because the Android 11 (API 30) does not support JPG as a MIME type, causing the following error:

`java.lang.IllegalArgumentException: Unsupported MIME type image/jpg`