### PR TITLE
SDPMS-3057 Block rotating the device while editing the picture

### DIFF
--- a/imageeditlibrary/src/main/AndroidManifest.xml
+++ b/imageeditlibrary/src/main/AndroidManifest.xml
@@ -5,6 +5,7 @@
         <!--图片编辑Activity-->
         <activity
             android:name="com.xinlan.imageeditlibrary.editimage.EditImageActivity"
+            android:screenOrientation="portrait"
             android:theme="@style/Theme.AppCompat.Light.NoActionBar">
         </activity>
     </application>


### PR DESCRIPTION
## Description ✍️
This PR is a workaoround to fix a bug that when the user rotate the device while edit it lose all the edition made in the picture

## Evidences 📱

### Before
https://github.com/user-attachments/assets/bc57ba4f-953f-461d-bb9c-99b23ec91a88

### After
https://github.com/user-attachments/assets/b97402f7-234c-47ce-add1-6648b140a382
